### PR TITLE
Fixed wrong formatting in BuildingPart XML

### DIFF
--- a/SAP_Engine/Convert/BuildingPart.cs
+++ b/SAP_Engine/Convert/BuildingPart.cs
@@ -65,36 +65,37 @@ namespace BH.Engine.Environment.SAP
                         openingTypes.OpeningType.AddRange(opening[u].OpeningType.ToXML().OpeningType); //method to only keep unique ones
                     }
 
-                    xmlBuildingPart.Openings = new List<oM.Environment.SAP.XML.Opening>();
+                    xmlBuildingPart.Openings = new oM.Environment.SAP.XML.Openings();
                     for (int v = 0; v < sapBuildingPart[i].Roofs.Count; v++)
                     {
-                        xmlBuildingPart.Openings.AddRange(outputRoof[v].Item2);
+                        xmlBuildingPart.Openings.Opening.AddRange(outputRoof[v].Item2);
                     }
                     for (int v = 0; v < sapBuildingPart[i].Walls.Count; v++)
                     {
-                        xmlBuildingPart.Openings.AddRange(outputWall[v].Item2);
+                        xmlBuildingPart.Openings.Opening.AddRange(outputWall[v].Item2);
                     }
                 }
 
-                List<oM.Environment.SAP.XML.FloorDimension> xmlFloorDimensions = new List<oM.Environment.SAP.XML.FloorDimension>();
-                xmlFloorDimensions.Add(ToXML(sapBuildingPart[i].Floor, sapBuildingPart[i].Storeys));
+                oM.Environment.SAP.XML.FloorDimensions xmlFloorDimensions = new oM.Environment.SAP.XML.FloorDimensions();
+                xmlFloorDimensions.FloorDimension.Add(ToXML(sapBuildingPart[i].Floor, sapBuildingPart[i].Storeys));
                 xmlBuildingPart.Floors = xmlFloorDimensions;
+
+                BH.oM.Environment.SAP.XML.Roofs xmlRoofList = new BH.oM.Environment.SAP.XML.Roofs();
                 for (int u = 0; u < outputRoof.Count; u++)
                 {
                     BH.oM.Environment.SAP.XML.Roof xmlRoof = outputRoof[u].Item1;
-                    List<BH.oM.Environment.SAP.XML.Roof> xmlRoofList = new List<BH.oM.Environment.SAP.XML.Roof>();
-                    xmlRoofList.Add(xmlRoof);
-                    xmlBuildingPart.Roofs = xmlRoofList; 
+                    xmlRoofList.Roof.Add(xmlRoof);
                 }
 
+                xmlBuildingPart.Roofs = xmlRoofList;
+                BH.oM.Environment.SAP.XML.Walls xmlWallList = new oM.Environment.SAP.XML.Walls();
                 for (int u = 0; u < outputWall.Count; u++)
                 {
                     BH.oM.Environment.SAP.XML.Wall xmlWall = outputWall[u].Item1;
-                    List<BH.oM.Environment.SAP.XML.Wall> xmlWallList = new List<BH.oM.Environment.SAP.XML.Wall>();
-                    xmlWallList.Add(xmlWall);
-                    xmlBuildingPart.Walls = xmlWallList;
-                } 
+                    xmlWallList.Wall.Add(xmlWall);
+                }
 
+                xmlBuildingPart.Walls = xmlWallList;
                 xmlBuildingPart.ThermalBridges = sapBuildingPart[i].ThermalBridges.Select(x => x.ToXML()).ToList();
                 xmlBuildingParts.Add(xmlBuildingPart);
             }

--- a/SAP_oM/SAP_oM.csproj
+++ b/SAP_oM/SAP_oM.csproj
@@ -160,8 +160,11 @@
     <Compile Include="XML\DeselectedImprovements.cs" />
     <Compile Include="XML\EnergySource.cs" />
     <Compile Include="XML\FlatDetails.cs" />
+    <Compile Include="XML\FloorDimensions.cs" />
     <Compile Include="XML\HeatingDeclaredValues.cs" />
+    <Compile Include="XML\Openings.cs" />
     <Compile Include="XML\OpeningTypes.cs" />
+    <Compile Include="XML\Roofs.cs" />
     <Compile Include="XML\SAP2012Data.cs" />
     <Compile Include="XML\SpecialFeature.cs" />
     <Compile Include="XML\SpecialFeatures.cs" />
@@ -189,6 +192,7 @@
     <Compile Include="XML\ThermalBridge.cs" />
     <Compile Include="XML\Ventilation.cs" />
     <Compile Include="XML\Wall.cs" />
+    <Compile Include="XML\Walls.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />

--- a/SAP_oM/XML/FloorDimensions.cs
+++ b/SAP_oM/XML/FloorDimensions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
@@ -30,34 +30,11 @@ using System.Xml.Serialization;
 namespace BH.oM.Environment.SAP.XML
 {
     [Serializable]
-    [XmlRoot(ElementName = "SAP-Building-Part", IsNullable = false)]
-    public class BuildingPart : IObject
+    [XmlRoot(ElementName = "SAP-Floor-Dimensions", IsNullable = false)]
+    public class FloorDimensions : IObject
     {
-        [XmlElement("Building-Part-Number")]
-        public virtual string BuildingPartNumber { get; set; } = "1";
+        [XmlElement("SAP-Floor-Dimension")]
+        public virtual List<FloorDimension> FloorDimension { get; set; } = new List<FloorDimension>();
 
-        [XmlElement("Identifier")]
-        public virtual string Identifier { get; set; } = "Main dwelling";
-
-        [XmlElement("Construction-Year")]
-        public virtual string ConstructionYear { get; set; } = DateTime.Now.Year.ToString();
-
-        [XmlElement("Overshading")]
-        public virtual string Overshading { get; set; } = "2";
-
-        [XmlElement("SAP-Openings")]
-        public virtual Openings Openings { get; set; }
-
-        [XmlElement("SAP-Floor-Dimensions")]
-        public virtual FloorDimensions Floors { get; set; }
-
-        [XmlElement("SAP-Roofs")]
-        public virtual Roofs Roofs { get; set; }
-
-        [XmlElement("SAP-Walls")]
-        public virtual Walls Walls { get; set; }
-
-        [XmlElement("SAP-Thermal-Bridges")]
-        public virtual List<ThermalBridge> ThermalBridges { get; set; }
     }
 }

--- a/SAP_oM/XML/Openings.cs
+++ b/SAP_oM/XML/Openings.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
@@ -30,34 +30,12 @@ using System.Xml.Serialization;
 namespace BH.oM.Environment.SAP.XML
 {
     [Serializable]
-    [XmlRoot(ElementName = "SAP-Building-Part", IsNullable = false)]
-    public class BuildingPart : IObject
+    [XmlRoot(ElementName = "SAP-Openings", IsNullable = false)]
+    public class Openings : IObject
     {
-        [XmlElement("Building-Part-Number")]
-        public virtual string BuildingPartNumber { get; set; } = "1";
+        [XmlElement("SAP-Opening")]
+        public virtual List<Opening> Opening { get; set; } = new List<Opening>();
 
-        [XmlElement("Identifier")]
-        public virtual string Identifier { get; set; } = "Main dwelling";
-
-        [XmlElement("Construction-Year")]
-        public virtual string ConstructionYear { get; set; } = DateTime.Now.Year.ToString();
-
-        [XmlElement("Overshading")]
-        public virtual string Overshading { get; set; } = "2";
-
-        [XmlElement("SAP-Openings")]
-        public virtual Openings Openings { get; set; }
-
-        [XmlElement("SAP-Floor-Dimensions")]
-        public virtual FloorDimensions Floors { get; set; }
-
-        [XmlElement("SAP-Roofs")]
-        public virtual Roofs Roofs { get; set; }
-
-        [XmlElement("SAP-Walls")]
-        public virtual Walls Walls { get; set; }
-
-        [XmlElement("SAP-Thermal-Bridges")]
-        public virtual List<ThermalBridge> ThermalBridges { get; set; }
     }
 }
+

--- a/SAP_oM/XML/Roofs.cs
+++ b/SAP_oM/XML/Roofs.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
@@ -30,34 +30,11 @@ using System.Xml.Serialization;
 namespace BH.oM.Environment.SAP.XML
 {
     [Serializable]
-    [XmlRoot(ElementName = "SAP-Building-Part", IsNullable = false)]
-    public class BuildingPart : IObject
+    [XmlRoot(ElementName = "SAP-Roofs", IsNullable = false)]
+    public class Roofs : IObject
     {
-        [XmlElement("Building-Part-Number")]
-        public virtual string BuildingPartNumber { get; set; } = "1";
+        [XmlElement("SAP-Roof")]
+        public virtual List<Roof> Roof { get; set; } = new List<Roof>();
 
-        [XmlElement("Identifier")]
-        public virtual string Identifier { get; set; } = "Main dwelling";
-
-        [XmlElement("Construction-Year")]
-        public virtual string ConstructionYear { get; set; } = DateTime.Now.Year.ToString();
-
-        [XmlElement("Overshading")]
-        public virtual string Overshading { get; set; } = "2";
-
-        [XmlElement("SAP-Openings")]
-        public virtual Openings Openings { get; set; }
-
-        [XmlElement("SAP-Floor-Dimensions")]
-        public virtual FloorDimensions Floors { get; set; }
-
-        [XmlElement("SAP-Roofs")]
-        public virtual Roofs Roofs { get; set; }
-
-        [XmlElement("SAP-Walls")]
-        public virtual Walls Walls { get; set; }
-
-        [XmlElement("SAP-Thermal-Bridges")]
-        public virtual List<ThermalBridge> ThermalBridges { get; set; }
     }
 }

--- a/SAP_oM/XML/Walls.cs
+++ b/SAP_oM/XML/Walls.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
@@ -30,34 +30,11 @@ using System.Xml.Serialization;
 namespace BH.oM.Environment.SAP.XML
 {
     [Serializable]
-    [XmlRoot(ElementName = "SAP-Building-Part", IsNullable = false)]
-    public class BuildingPart : IObject
+    [XmlRoot(ElementName = "SAP-Walls", IsNullable = false)]
+    public class Walls : IObject
     {
-        [XmlElement("Building-Part-Number")]
-        public virtual string BuildingPartNumber { get; set; } = "1";
+        [XmlElement("SAP-Wall")]
+        public virtual List<Wall> Wall { get; set; } = new List<Wall>();
 
-        [XmlElement("Identifier")]
-        public virtual string Identifier { get; set; } = "Main dwelling";
-
-        [XmlElement("Construction-Year")]
-        public virtual string ConstructionYear { get; set; } = DateTime.Now.Year.ToString();
-
-        [XmlElement("Overshading")]
-        public virtual string Overshading { get; set; } = "2";
-
-        [XmlElement("SAP-Openings")]
-        public virtual Openings Openings { get; set; }
-
-        [XmlElement("SAP-Floor-Dimensions")]
-        public virtual FloorDimensions Floors { get; set; }
-
-        [XmlElement("SAP-Roofs")]
-        public virtual Roofs Roofs { get; set; }
-
-        [XmlElement("SAP-Walls")]
-        public virtual Walls Walls { get; set; }
-
-        [XmlElement("SAP-Thermal-Bridges")]
-        public virtual List<ThermalBridge> ThermalBridges { get; set; }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #60 

<!-- Add short description of what has been fixed -->
Fixed formatting issue for the pushed XML file
Added files in SAP.XML
Walls.cs
Roofs.cs
FloorDimensions.cs
and Openings.cs
to make the XML definition for BuildingPart comply with the SAP-Schema.
Changes in BUldingPArt.cs and BuildingPart convert method to integrate the added files.

### Test files
<!-- Link to test files to validate the proposed changes -->
[here](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/SAP_Toolkit/%2361.gh?csf=1&web=1&e=oss0WK)

