### PR TITLE
Methods to query areas

### DIFF
--- a/SAP_Adapter/Convert/Argyle/Floor.cs
+++ b/SAP_Adapter/Convert/Argyle/Floor.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.Environment.SAP
 
                 xmlFloor.Storey = sapFloorDimensions[i].Storey.StoreyNumber.ToString();
                 xmlFloor.StoreyHeight = sapFloorDimensions[i].Storey.StoreyNumber.ToString();
-                xmlFloor.Area = sapFloorDimensions[i].Storey.Area.ToString();
+                xmlFloor.Area = sapFloorDimensions[i].Storey.Area;
 
                 xmlFloors.Add(xmlFloor);
             }

--- a/SAP_Adapter/Convert/Argyle/Roof.cs
+++ b/SAP_Adapter/Convert/Argyle/Roof.cs
@@ -56,8 +56,8 @@ namespace BH.Engine.Environment.SAP
                 xmlOpening.Type = sapRoof.Openings[i].OpeningType.Type.ToString();
                 xmlOpening.Location = sapRoof.Name;
                 xmlOpening.Orientation = sapRoof.Openings[i].Orientation.FromSAPToXML();
-                xmlOpening.Width = sapRoof.Openings[i].Width.ToString(); 
-                xmlOpening.Height = sapRoof.Openings[i].Height.ToString();
+                xmlOpening.Width = sapRoof.Openings[i].Width; 
+                xmlOpening.Height = sapRoof.Openings[i].Height;
                 xmlOpening.Pitch = sapRoof.Pitch.FromSAPToXML();
                 xmlOpenings.Add(xmlOpening);
             }

--- a/SAP_Adapter/Convert/Argyle/Wall.cs
+++ b/SAP_Adapter/Convert/Argyle/Wall.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Environment.SAP
             xmlWall.Name = sapWall.Name;
             xmlWall.Description = "Type-" + sapWall.Type.ToString() + "_Area-" + sapWall.Area.ToString() + "_Uvalue-" + "0.18";
             xmlWall.Type = sapWall.Type.FromSAPToXML();
-            xmlWall.Area = sapWall.Area.ToString();
+            xmlWall.Area = sapWall.Area;
             xmlWall.UValue = sapWall.uValue.ToString();
             xmlWall.KappaValue = sapWall.KappaValue.ToString();
             xmlWall.CurtainWall = sapWall.CurtainWall;
@@ -56,8 +56,8 @@ namespace BH.Engine.Environment.SAP
                 xmlOpening.Type = sapWall.Openings[i].OpeningType.Type.ToString();
                 xmlOpening.Location = sapWall.Name;
                 xmlOpening.Orientation = sapWall.Openings[i].Orientation.FromSAPToXML();
-                xmlOpening.Width = sapWall.Openings[i].Width.ToString();
-                xmlOpening.Height = sapWall.Openings[i].Height.ToString();
+                xmlOpening.Width = sapWall.Openings[i].Width;
+                xmlOpening.Height = sapWall.Openings[i].Height;
                 xmlOpenings.Add(xmlOpening);
             }
             return new Output<BH.oM.Environment.SAP.XML.Wall, List<BH.oM.Environment.SAP.XML.Opening>>() { Item1 = xmlWall, Item2 = xmlOpenings };

--- a/SAP_Engine/Modify/Opening.cs
+++ b/SAP_Engine/Modify/Opening.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Environment.SAP
         [Input("width", "New width for windows.")]
         [Input("pitch", "New pitch for windows.")]
         [Output("sapReport", "The modified SAP Report object.")]
-        public static SAPReport ModifyOpenings(this SAPReport sapObj, List<string> include, string height, string width, string pitch)
+        public static SAPReport ModifyOpenings(this SAPReport sapObj, List<string> include, double height, double width, string pitch)
         {
             List<BH.oM.Environment.SAP.XML.BuildingPart> buildingPartList = new List<oM.Environment.SAP.XML.BuildingPart>();
 
@@ -85,14 +85,14 @@ namespace BH.Engine.Environment.SAP
         [Input("width", "New width for windows.")]
         [Input("pitch", "New pitch for windows.")]
         [Output("opening", "The modified SAP opening object.")]
-        public static BH.oM.Environment.SAP.XML.Opening ModifyOpening(this BH.oM.Environment.SAP.XML.Opening opening, string height, string width, string pitch)
+        public static BH.oM.Environment.SAP.XML.Opening ModifyOpening(this BH.oM.Environment.SAP.XML.Opening opening, double height, double width, string pitch)
         {
-            if (height != null)
+            if (height < 0)
             {
                 opening.Height = height;
             }
 
-            if (width != null)
+            if (width < 0)
             {
                 opening.Width = width;
             }

--- a/SAP_Engine/Modify/OpeningType.cs
+++ b/SAP_Engine/Modify/OpeningType.cs
@@ -55,6 +55,7 @@ namespace BH.Engine.Environment.SAP
         [Output("sapReport", "The modified SAP Report object.")]
         public static SAPReport ModifyOpeningTypes(this SAPReport sapObj, string type, List<string> include, double uvalue = -1, double gvalue = -1)
         {
+
             //If no valid values have been set
             if ((uvalue < 0) && (gvalue < 0))
             {

--- a/SAP_Engine/Modify/ThermalBridgesFromOpening.cs
+++ b/SAP_Engine/Modify/ThermalBridgesFromOpening.cs
@@ -120,14 +120,15 @@ namespace BH.Engine.Environment.SAP
                         //Assign properties
                         thermalBridge.Type = i.Item1;
                         thermalBridge.PsiValue = i.Item2;
+                        thermalBridge.PsiSource = "3";
                         thermalBridge.CalculationReference = $"{opening.Name}_{opening.Type}_{opening.Location}";
                         if (i.Item1.EndsWith("3")) 
                         { 
-                            thermalBridge.Length = double.Parse(opening.Height); 
+                            thermalBridge.Length = opening.Height; 
                         }
                         else 
                         { 
-                            thermalBridge.Length = double.Parse(opening.Width); 
+                            thermalBridge.Length = opening.Width; 
                         }
 
                         thermalBridges.Add(thermalBridge);
@@ -160,14 +161,15 @@ namespace BH.Engine.Environment.SAP
                         //Assign properties
                         tb.Type = i.Item1;
                         tb.PsiValue = i.Item2;
+                        tb.PsiSource = "3";
                         tb.CalculationReference = $"{opening.Name}_{opening.Type}_{opening.Location}";
                         if (i.Item1.EndsWith("4"))
                         { 
-                            tb.Length = double.Parse(opening.Height); 
+                            tb.Length = opening.Height; 
                         }
                         else 
                         { 
-                            tb.Length = double.Parse(opening.Width); 
+                            tb.Length = opening.Width; 
                         }
 
                         thermalBridges.Add(tb);

--- a/SAP_Engine/Query/WallArea.cs
+++ b/SAP_Engine/Query/WallArea.cs
@@ -22,45 +22,43 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using BH.oM.Base;
-using System.Xml.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.IO;
 
-namespace BH.oM.Environment.SAP.XML
+using BH.oM.Environment.MaterialFragments;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using BH.oM.Environment.SAP.XML;
+using BH.Engine.Base;
+
+namespace BH.Engine.Environment.SAP
 {
-    [Serializable]
-    [XmlRoot(ElementName = "SAP-Wall", IsNullable = false)]
-    public class Wall : IObject
+    public static partial class Query
     {
-        [Description("Unique name which identifies this wall within its storey.  Can be just a number, e.g. \"1\".  However, a wall cannot have the same name as an opening or a roof.")]
-        [XmlElement("Name")]
-        public virtual string Name { get; set; } = "Walls (1)";
+        [Description("From a SAPReport, returns the wall area of the dwelling.")]
+        [Input("report", "The report to get the wall data from.")]
+        [Output("Area", "The total wall area of the dwelling.")]
+        public static double WallArea(this SAPReport report)
+        {
+            double wallArea = 0;
 
-        [Description("Descriptive notes about the wall.")]
-        [XmlElement("Description")]
-        public virtual string Description { get; set; } = null;
+            foreach (var buildingPart in report.SAP10Data.PropertyDetails.BuildingParts.BuildingPart)
+            {
+                var walls = buildingPart.Walls.Wall;
 
-        [Description("Total wall area in square metres, inclusive of any openings.")]
-        [XmlElement("Total-Wall-Area")]
-        public virtual double Area { get; set; } = -1;
+                if (walls.IsNullOrEmpty())
+                {
+                    BH.Engine.Base.Compute.RecordError("This is not a valid dwelling as it does not have walls. Please add these to your dwelling.");
+                    return 0;
+                }
+                wallArea += walls.Select(x => x.Area).Sum();
+            }
 
-        [Description("Exposed wall U-value.")]
-        [XmlElement("U-Value")]
-        public virtual string UValue { get; set; } = "0.18"; //0.18
-
-        [Description("Type of wall (exposure).")]
-        [XmlElement("Wall-Type")]
-        public virtual string Type { get; set; } = "2"; //2
-
-        [Description("Heat capacity per unit area in kJ/m�K.")]
-        [XmlElement("Kappa-Value")]
-        public virtual string KappaValue { get; set; } = null; //14
-
-
-        [Description("Whether the wall is curtain walling.")]
-        [XmlElement("Is-Curtain-Walling")]
-        public virtual bool CurtainWall { get; set; } = false;
+            return wallArea;
+        }
     }
 }
-

--- a/SAP_Engine/Query/WindowArea.cs
+++ b/SAP_Engine/Query/WindowArea.cs
@@ -16,7 +16,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
  * GNU Lesser General Public License for more details.                          
  *                                                                            
- * You should have received openingTypes copy of the GNU Lesser General Public License     
+ * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 

--- a/SAP_Engine/Query/WindowArea.cs
+++ b/SAP_Engine/Query/WindowArea.cs
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received openingTypes copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.IO;
+
+using BH.oM.Environment.MaterialFragments;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using BH.oM.Environment.SAP.XML;
+using System.Xml.Serialization;
+using BH.Engine.Base;
+
+namespace BH.Engine.Environment.SAP
+{
+    public static partial class Query
+    {
+        [Description("From openingTypes SAPReport, returns the total window area of the dwelling.")]
+        [Input("report", "The report to get the opening data from.")]
+        [Output("Area", "The total window area of the dwelling.")]
+        public static double WindowArea(this SAPReport report)
+        {
+            double windowArea = 0;
+
+            var types = report.SAP10Data.PropertyDetails.OpeningTypes.OpeningType;
+
+            if (types.IsNullOrEmpty())
+            {
+                BH.Engine.Base.Compute.RecordError("Opening Types are not defined properly for this dwelling.");
+                return 0;
+            }
+
+            var openingTypes = report.SAP10Data.PropertyDetails.OpeningTypes.OpeningType.Select(x => new { x.Name, x.Type }).ToDictionary(x => x.Name, x => x.Type);
+
+            foreach (var buildingPart in report.SAP10Data.PropertyDetails.BuildingParts.BuildingPart)
+            {
+                var openings = buildingPart.Openings.Opening;
+
+                if (openings.IsNullOrEmpty())
+                {
+                    BH.Engine.Base.Compute.RecordError("There are no openings in this dwelling. Are you sure this is correct? Please add these to your dwelling if needed.");
+                    return 0;
+                }
+
+                windowArea += buildingPart.Openings.Opening.Where(x => (openingTypes[x.Type] != "1" || openingTypes[x.Type] != "2" || openingTypes[x.Type] != "3")).Select(x => (x.Width * x.Height)).Sum();
+            }
+
+            return windowArea;
+        }
+    }
+}

--- a/SAP_oM/Iteration/OpeningIterator.cs
+++ b/SAP_oM/Iteration/OpeningIterator.cs
@@ -38,10 +38,10 @@ namespace BH.oM.Environment.SAP.XML
     public class OpeningIterator : IObject
     {
         [Description("New width of opening.")]
-        public virtual string Width { get; set; } = null;
+        public virtual double Width { get; set; } = -1;
 
         [Description("New height of the opening.")]
-        public virtual string Height { get; set; } = null;
+        public virtual double Height { get; set; } = -1;
 
         [Description("New pitch of opening.")]
         public virtual string Pitch { get; set; } = null;

--- a/SAP_oM/XML/FloorDimension.cs
+++ b/SAP_oM/XML/FloorDimension.cs
@@ -55,7 +55,7 @@ namespace BH.oM.Environment.SAP.XML
 
         [Description("The total floor area of the storey in square metres.")]
         [XmlElement("Total-Floor-Area")]
-        public virtual string Area { get; set; } = "0";
+        public virtual double Area { get; set; } = -1;
 
         [Description("Heat loss floor U-value.")]
         [XmlElement("U-Value")]

--- a/SAP_oM/XML/Opening.cs
+++ b/SAP_oM/XML/Opening.cs
@@ -47,11 +47,11 @@ namespace BH.oM.Environment.SAP.XML
 
         [Description("The height of the opening in metres.  If the Height field is used to record the opening area, set the Width to 1.")]
         [XmlElement("Height")]
-        public virtual string Height { get; set; } = null;
+        public virtual double Height { get; set; } = -1;
 
         [Description("The width of the opening in metres.  If the Width field is used to record the opening area, set the Height to 1.")]
         [XmlElement("Width")]
-        public virtual string Width { get; set; } = null;
+        public virtual double Width { get; set; } = -1;
 
         [Description("Compass direction in which the opening faces.")]
         [XmlElement("Orientation")]


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #92 

<!-- Add short description of what has been fixed -->

Creation of three methods to query wall area, total floor area, and wall area from a SAP report object. Changes were also made to how data such as area/width/height were stored within an xml object (changed from string to double) and other methods where changed to reflect this.
