### PR TITLE
Replacing IsNullOrEmpty

### DIFF
--- a/SAP_Engine/Modify/OpeningType.cs
+++ b/SAP_Engine/Modify/OpeningType.cs
@@ -106,7 +106,7 @@ namespace BH.Engine.Environment.SAP
                     //Finds in the dictionary the entry with the same type
                     var item = dict.Where(x => x.Value["Name"] == o.Type).FirstOrDefault().Value;
 
-                    if (!item.IsNullOrEmpty())
+                    if ((item != null) && item.Any())
                     {
                         openingObj = openingObj.ModifyOpeningType(item["NewName"]);
                     }


### PR DESCRIPTION
Closes #97 

<!-- Add short description of what has been fixed -->

This replaces the IsNullOrEmpty method in OpeningType.cs with ((item != null) && item.Any())

