### PR TITLE
Fix of logic errors within ModifyOpenings

### DIFF
--- a/SAP_Engine/Modify/Opening.cs
+++ b/SAP_Engine/Modify/Opening.cs
@@ -90,12 +90,12 @@ namespace BH.Engine.Environment.SAP
         [Output("opening", "The modified SAP opening object.")]
         public static BH.oM.Environment.SAP.XML.Opening ModifyOpening(this BH.oM.Environment.SAP.XML.Opening opening, double height, double width, string pitch)
         {
-            if (height < 0)
+            if (height > 0)
             {
                 opening.Height = height;
             }
 
-            if (width < 0)
+            if (width > 0)
             {
                 opening.Width = width;
             }

--- a/SAP_Engine/Modify/Opening.cs
+++ b/SAP_Engine/Modify/Opening.cs
@@ -51,6 +51,9 @@ namespace BH.Engine.Environment.SAP
         {
             List<BH.oM.Environment.SAP.XML.BuildingPart> buildingPartList = new List<oM.Environment.SAP.XML.BuildingPart>();
 
+            List<BH.oM.Environment.SAP.XML.OpeningType> types = sapObj.SAP10Data.PropertyDetails.OpeningTypes.OpeningType;
+            Dictionary<string, string> typeMap = types.Select(x => new { Key = x.Name, Value = x.Description }).ToDictionary(x => x.Key, x => x.Value);
+
             //Foreach building part in the dwelling
             foreach (var b in sapObj.SAP10Data.PropertyDetails.BuildingParts.BuildingPart)
             {
@@ -63,7 +66,7 @@ namespace BH.Engine.Environment.SAP
                     BH.oM.Environment.SAP.XML.Opening openingObj = o;
 
                     //If the opening object type is in include(list of opening Types to modify) then modify it.
-                    if (include.Contains(o.Type)) //change based on example
+                    if (include.Contains(typeMap[o.Type])) //change based on example
                     {
                         openingObj = openingObj.ModifyOpening(height, width, pitch);
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #101 

<!-- Add short description of what has been fixed -->

All of the opening types are assigned another name that is in line with the schema. The code was originally searching in the list of the second names instead of searching the original type the opening is assigned to. Then there was a mistake with the logic when changing the height/width of an opening. This has also been fixed.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->