### PR TITLE
Consolidate versions of external dependencies

### DIFF
--- a/Argyle_Adapter/AdapterActions/Execute.cs
+++ b/Argyle_Adapter/AdapterActions/Execute.cs
@@ -32,7 +32,6 @@ using BH.Engine.Environment.SAP;
 
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Text.Json;
 using System.Xml.Serialization;
 using System.IO;
 

--- a/Argyle_Adapter/Argyle_Adapter.csproj
+++ b/Argyle_Adapter/Argyle_Adapter.csproj
@@ -68,7 +68,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.Text.Json.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
   </Target>
 
 </Project>

--- a/Argyle_Adapter/Argyle_Adapter.csproj
+++ b/Argyle_Adapter/Argyle_Adapter.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SAP_Adapter/AdapterActions/Execute.cs
+++ b/SAP_Adapter/AdapterActions/Execute.cs
@@ -32,7 +32,6 @@ using BH.Engine.Environment.SAP;
 
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Text.Json;
 using System.Xml.Serialization;
 using System.IO;
 using System.Linq;

--- a/SAP_Adapter/SAP_Adapter.csproj
+++ b/SAP_Adapter/SAP_Adapter.csproj
@@ -14,7 +14,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.102.2" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SAP_Engine/SAP_Engine.csproj
+++ b/SAP_Engine/SAP_Engine.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SAP_Engine/SAP_Engine.csproj
+++ b/SAP_Engine/SAP_Engine.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #187

Upgrade System.Text.Json package version to 10.0.3 as version 6.0.1 has vulnerabilities: https://www.nuget.org/packages/System.Text.Json/6.0.1

Version 10.0.3 was chosen to be non-vulnerable and coherent with other toolkits. 

That being said, I don't know why that package is even referenced. Looking at the GitHub history on that repo, it seems that it was needed by code that doesn't exists anymore so it might be worth looking into removing it. I'm not going to do that here as I don't have any experience with this toolkit.

This PR also 
 - Upgrade CloseXML to eliminate a vulnerable dependency on System.IO.Packaging 6.0.0
 - Upgrade Microsoft.Windows.Compatibility to remove vulnerable dependency on System.Data.SqlClient 4.8.1

This is related to those PR and should be tested together:
- https://github.com/BHoM/Excel_Toolkit/pull/105
- https://github.com/BHoM/PowerPoint_Toolkit/pull/40

### Test files
Usual testing procedure.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->